### PR TITLE
feat: support assignments and promise syntax

### DIFF
--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -26,27 +26,81 @@ module.exports = {
   },
 
   create: function(context) {
+    const testingLibraryQueryUsage = [];
     return {
       [`CallExpression > Identifier[name=${ASYNC_QUERIES_REGEXP}]`](node) {
-        let hasError = true;
-        try {
-          if (VALID_PARENTS.includes(node.parent.parent.type)) {
-            hasError = false;
-          }
-        } catch (e) {
-          // not necessary to do anything
-        }
-
-        if (hasError) {
-          context.report({
+        testingLibraryQueryUsage.push(node);
+      },
+      'Program:exit'() {
+        testingLibraryQueryUsage.forEach(node => {
+          const variableDeclaratorParent = findParent(
             node,
-            messageId: 'awaitAsyncQuery',
-            data: {
-              name: node.name,
-            },
-          });
-        }
+            parent => parent.type === 'VariableDeclarator'
+          );
+
+          const references =
+            (variableDeclaratorParent &&
+              context
+                .getDeclaredVariables(variableDeclaratorParent)[0]
+                .references.slice(1)) ||
+            [];
+
+          if (
+            references.length === 0 &&
+            !isAwaited(node.parent.parent) &&
+            !isPromiseResolved(node)
+          ) {
+            context.report({
+              node,
+              messageId: 'awaitAsyncQuery',
+              data: {
+                name: node.name,
+              },
+            });
+          } else {
+            references.forEach(reference => {
+              const node = reference.identifier;
+              if (!isAwaited(node.parent) && !isPromiseResolved(node)) {
+                context.report({
+                  node: reference.identifier,
+                  messageId: 'awaitAsyncQuery',
+                  data: {
+                    name: node.name,
+                  },
+                });
+              }
+            });
+          }
+        });
       },
     };
   },
 };
+
+function isAwaited(node) {
+  return VALID_PARENTS.includes(node.type);
+}
+
+function isPromiseResolved(node) {
+  const parent = node.parent;
+
+  const hasAThenProperty = node =>
+    node.type === 'MemberExpression' && node.property.name === 'then';
+
+  // findByText("foo").then(...)
+  if (parent.type === 'CallExpression') {
+    return hasAThenProperty(parent.parent);
+  }
+
+  // promise.then(...)
+  return hasAThenProperty(parent);
+}
+
+function findParent(node, test) {
+  if (test(node)) {
+    return node;
+  } else if (node.parent) {
+    return findParent(node.parent, test);
+  }
+  return null;
+}

--- a/tests/lib/rules/await-async-query.js
+++ b/tests/lib/rules/await-async-query.js
@@ -26,6 +26,21 @@ ruleTester.run('await-async-query', rule, {
       `,
     },
     {
+      code: `() => {
+        findByText('foo').then(node => {
+          done()
+        })
+      }
+      `,
+    },
+    {
+      code: `() => {
+        const promise = findByText('foo')
+        promise.then(node => done())
+      }
+      `,
+    },
+    {
       code: `async () => {
         doSomething()
         const foo = await findByText('foo')


### PR DESCRIPTION
This PR intends to support the edge cases of the queries usage. That is to say:

- Assignments of the queries : 

```js
const promise = findByText('foo')
return promise
```

- Promise syntax

```js
const promise = findByText('foo')
promise.then(node => done())

// Or

findByText('foo').then(node => {
  done()
})
```

All tests passes but I consider the implementation to be a bit fragile.

Closes #1 
Closes #2 
