### PR TITLE
feat: add no-debug rule

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,6 +1,4 @@
 {
-  "*.js": [
-    "npm run lint:fix",
-    "git add"
-  ]
+  "*.js": ["eslint --fix", "git add"],
+  "*.md": ["prettier --write", "git add"]
 }

--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ To enable this configuration use the `extends` property in your `.eslintrc` conf
 | -------------------------------------------------------- | --------------------------------------------- | ---------------- |
 | [await-async-query](docs/rules/await-async-query.md)     | Enforce async queries to have proper `await`  | ![recommended][] |
 | [no-await-sync-query](docs/rules/no-await-sync-query.md) | Disallow unnecessary `await` for sync queries | ![recommended][] |
+| [no-debug](docs/rules/no-debug.md)                       | Disallow the use of `debug`                   |                  |
 
 [recommended]: https://img.shields.io/badge/recommended-lightgrey?style=flat-square

--- a/README.md
+++ b/README.md
@@ -53,18 +53,6 @@ To enable this configuration use the `extends` property in your `.eslintrc` conf
 }
 ```
 
-### All
-
-If you want to enable all rules instead of only some you can do so by adding the `all` configuration to your `.eslintrc` config file:
-
-```json
-{
-  "extends": ["plugin:testing-library/all"]
-}
-```
-
-While the `recommended` configuration only change in major versions, the `all` configuration may change in any release and is thus unsuited for installations requiring long-term consistency.
-
 ## Supported Rules
 
 | Rule                                                     | Description                                   | Recommended      |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
     <img width="150" height="150" src="https://eslint.org/assets/img/logo.svg">
   </a>
   <a href="https://testing-library.com/">
-    <img width="150" height="150" vspace="" hspace="25" src="https://raw.githubusercontent.com/testing-library/dom-testing-library/master/other/octopus.png">
+    <img width="150" height="150" src="https://raw.githubusercontent.com/testing-library/dom-testing-library/master/other/octopus.png">
   </a>
   <h1>eslint-plugin-testing-library</h1>
   <p>ESLint plugin for Testing Library</p>

--- a/README.md
+++ b/README.md
@@ -24,21 +24,18 @@ Add `testing-library` to the plugins section of your `.eslintrc` configuration f
 
 ```json
 {
-    "plugins": [
-        "testing-library"
-    ]
+  "plugins": ["testing-library"]
 }
 ```
-
 
 TODO: Then configure the rules you want to use under the rules section.
 
 ```json
 {
-    "rules": {
-        "testing-library/await-async-query": "warn",
-        "testing-library/no-await-sync-query": "error"
-    }
+  "rules": {
+    "testing-library/await-async-query": "warn",
+    "testing-library/no-await-sync-query": "error"
+  }
 }
 ```
 
@@ -70,9 +67,4 @@ While the `recommended` configuration only change in major versions, the `all` c
 
 ## Supported Rules
 
-* TODO
-
-
-
-
-
+- TODO

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
-# eslint-plugin-testing-library
-
-ESLint plugin for Testing Library
+<div align="center">
+  <a href="https://eslint.org/">
+    <img width="150" height="150" src="https://eslint.org/assets/img/logo.svg">
+  </a>
+  <a href="https://testing-library.com/">
+    <img width="150" height="150" vspace="" hspace="25" src="https://raw.githubusercontent.com/testing-library/dom-testing-library/master/other/octopus.png">
+  </a>
+  <h1>eslint-plugin-testing-library</h1>
+  <p>ESLint plugin for Testing Library</p>
+</div>
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add `testing-library` to the plugins section of your `.eslintrc` configuration f
 }
 ```
 
-TODO: Then configure the rules you want to use under the rules section.
+Then configure the rules you want to use under the rules section.
 
 ```json
 {
@@ -67,4 +67,9 @@ While the `recommended` configuration only change in major versions, the `all` c
 
 ## Supported Rules
 
-- TODO
+| Rule                                                     | Description                                   | Recommended      |
+| -------------------------------------------------------- | --------------------------------------------- | ---------------- |
+| [await-async-query](docs/rules/await-async-query.md)     | Enforce async queries to have proper `await`  | ![recommended][] |
+| [no-await-sync-query](docs/rules/no-await-sync-query.md) | Disallow unnecessary `await` for sync queries | ![recommended][] |
+
+[recommended]: https://img.shields.io/badge/recommended-lightgrey?style=flat-square

--- a/docs/rules/await-async-query.md
+++ b/docs/rules/await-async-query.md
@@ -1,31 +1,60 @@
 # Enforce async queries to have proper `await` (await-async-query)
 
-TODO: Please describe the origin of the rule here.
+Ensure that promises returned by async queries are handled properly.
 
 ## Rule Details
 
-This rule aims to...
+Some of the queries variants that Testing Library provides are
+asynchronous as they return a promise which resolves when elements are
+found. Those queries variants are:
+
+- `findBy*`
+- `findByAll*`
+
+This rule aims to prevent users from forgetting to await the returned
+promise from those async queries to be fulfilled, which could lead to
+errors in the tests. The promises can be handled by using either `await`
+operator or `then` method.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-// TODO: fill me in
+const foo = () => {
+  // ...
+  const rows = findAllByRole('row');
+  // ...
+};
+
+const bar = () => {
+  // ...
+  findByText('submit');
+  // ...
+};
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-// TODO: fill me in
+// `await` operator is correct
+const foo = async () => {
+  // ...
+  const rows = await findAllByRole('row');
+  // ...
+};
+
+// `then` method is correct
+const bar = () => {
+  // ...
+  findByText('submit').then(() => {
+    // ...
+  });
+};
+
+// return the promise within a function is correct too!
+const findMyButton = () => findByText('my button');
 ```
-
-### Options
-
-TODO: If there are any options, describe them here. Otherwise, delete this section.
-
-## When Not To Use It
-
-TODO: Give a short description of when it would be appropriate to turn off this rule.
 
 ## Further Reading
 
+- [Async queries variants](https://testing-library.com/docs/dom-testing-library/api-queries#findby)
 - [Testing Library queries cheatsheet](https://testing-library.com/docs/dom-testing-library/cheatsheet#queries)

--- a/docs/rules/await-async-query.md
+++ b/docs/rules/await-async-query.md
@@ -1,4 +1,4 @@
-# Enforce async queries (`findBy*`, `findAllBy*`) to have proper `await` (await-async-query)
+# Enforce async queries to have proper `await` (await-async-query)
 
 TODO: Please describe the origin of the rule here.
 

--- a/docs/rules/await-async-query.md
+++ b/docs/rules/await-async-query.md
@@ -2,7 +2,6 @@
 
 TODO: Please describe the origin of the rule here.
 
-
 ## Rule Details
 
 This rule aims to...
@@ -10,17 +9,13 @@ This rule aims to...
 Examples of **incorrect** code for this rule:
 
 ```js
-
 // TODO: fill me in
-
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-
 // TODO: fill me in
-
 ```
 
 ### Options

--- a/docs/rules/no-await-sync-query.md
+++ b/docs/rules/no-await-sync-query.md
@@ -2,7 +2,6 @@
 
 TODO: Please describe the origin of the rule here.
 
-
 ## Rule Details
 
 This rule aims to...
@@ -10,17 +9,13 @@ This rule aims to...
 Examples of **incorrect** code for this rule:
 
 ```js
-
 // TODO: fill me in
-
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-
 // TODO: fill me in
-
 ```
 
 ### Options

--- a/docs/rules/no-await-sync-query.md
+++ b/docs/rules/no-await-sync-query.md
@@ -1,31 +1,53 @@
 # Disallow unnecessary `await` for sync queries (no-await-sync-query)
 
-TODO: Please describe the origin of the rule here.
+Ensure sync queries
 
 ## Rule Details
 
-This rule aims to...
+Usual queries variants that Testing Library provides are synchronous and
+don't need to wait for any element. Those queries are:
+
+- `getBy*`
+- `getByAll*`
+- `queryBy*`
+- `queryAllBy*`
+
+This rule aims to prevent users from waiting for synchronous queries.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-// TODO: fill me in
+const foo = async () => {
+  // ...
+  const rows = await queryAllByRole('row');
+  // ...
+};
+
+const bar = () => {
+  // ...
+  getByText('submit').then(() => {
+    // ...
+  });
+};
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-// TODO: fill me in
+const foo = () => {
+  // ...
+  const rows = queryAllByRole('row');
+  // ...
+};
+
+const bar = () => {
+  // ...
+  const button = getByText('submit');
+  // ...
+};
 ```
-
-### Options
-
-TODO: If there are any options, describe them here. Otherwise, delete this section.
-
-## When Not To Use It
-
-TODO: Give a short description of when it would be appropriate to turn off this rule.
 
 ## Further Reading
 
+- [Sync queries variants](https://testing-library.com/docs/dom-testing-library/api-queries#variants)
 - [Testing Library queries cheatsheet](https://testing-library.com/docs/dom-testing-library/cheatsheet#queries)

--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -1,0 +1,31 @@
+# Disallow unnecessary `await` for sync queries (no-await-sync-query)
+
+TODO: Please describe the origin of the rule here.
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// TODO: fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// TODO: fill me in
+
+```
+
+### Options
+
+TODO: If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+TODO: Give a short description of when it would be appropriate to turn off this rule.

--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -1,31 +1,20 @@
-# Disallow unnecessary `await` for sync queries (no-await-sync-query)
+# Disallow the use of `debug` (no-debug)
 
-TODO: Please describe the origin of the rule here.
+Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your team mates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
 
 ## Rule Details
 
-This rule aims to...
+This rule aims to disallow the use of `debug` in your tests.
 
 Examples of **incorrect** code for this rule:
 
 ```js
-
-// TODO: fill me in
-
+test('invalid debug', () => {
+  const { debug } = render(<Hello />);
+  debug();
+});
 ```
 
-Examples of **correct** code for this rule:
+## Further Reading
 
-```js
-
-// TODO: fill me in
-
-```
-
-### Options
-
-TODO: If there are any options, describe them here. Otherwise, delete this section.
-
-## When Not To Use It
-
-TODO: Give a short description of when it would be appropriate to turn off this rule.
+- [debug API in React Testing Library](https://testing-library.com/docs/react-testing-library/api#debug)

--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -9,10 +9,11 @@ This rule aims to disallow the use of `debug` in your tests.
 Examples of **incorrect** code for this rule:
 
 ```js
-test('invalid debug', () => {
-  const { debug } = render(<Hello />);
-  debug();
-});
+const { debug } = render(<Hello />);
+debug();
+// OR
+const utils = render(<Hello />);
+utils.debug();
 ```
 
 ## Further Reading

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 const rules = {
   'await-async-query': require('./rules/await-async-query'),
   'no-await-sync-query': require('./rules/no-await-sync-query'),
+  'no-debug': require('./rules/no-debug'),
 };
 
 module.exports = {
@@ -13,6 +14,7 @@ module.exports = {
       rules: {
         'testing-library/await-async-query': 'error',
         'testing-library/no-await-sync-query': 'error',
+        'testing-library/no-debug': 'warn',
       },
     },
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,10 +8,6 @@ const rules = {
 module.exports = {
   rules,
   configs: {
-    all: {
-      plugins: ['testing-library'],
-      rules,
-    },
     recommended: {
       plugins: ['testing-library'],
       rules: {

--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getDocsUrl } = require('../utils');
+
 const VALID_PARENTS = [
   'AwaitExpression',
   'ArrowFunctionExpression',
@@ -15,7 +17,7 @@ module.exports = {
       description: 'Enforce async queries to have proper `await`',
       category: 'Best Practices',
       recommended: true,
-      url: 'TODO',
+      url: getDocsUrl('await-async-query'),
     },
     messages: {
       awaitAsyncQuery: '`{{ name }}` must have `await` operator',

--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -12,8 +12,7 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description:
-        'Enforce async queries (`findBy*`, `findAllBy*`) to have proper `await`',
+      description: 'Enforce async queries to have proper `await`',
       category: 'Best Practices',
       recommended: true,
       url: 'TODO',

--- a/lib/rules/no-await-sync-query.js
+++ b/lib/rules/no-await-sync-query.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getDocsUrl } = require('../utils');
+
 const SYNC_QUERIES_REGEXP = /^(get|query)(All)?By(LabelText|PlaceholderText|Text|AltText|Title|DisplayValue|Role|TestId)$/;
 
 module.exports = {
@@ -9,7 +11,7 @@ module.exports = {
       description: 'Disallow unnecessary `await` for sync queries',
       category: 'Best Practices',
       recommended: true,
-      url: 'TODO',
+      url: getDocsUrl('no-await-sync-query'),
     },
     messages: {
       noAwaitSyncQuery: '`{{ name }}` does not need `await` operator',

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -18,24 +18,50 @@ module.exports = {
 
   create: function(context) {
     let hasDestructuredDebugStatement = false;
+    const renderVariableDeclarators = [];
     return {
       VariableDeclarator(node) {
-        if (
-          node.init.callee.name === 'render' &&
-          node.id.type === 'ObjectPattern' &&
-          node.id.properties.some(property => property.key.name === 'debug')
-        ) {
-          hasDestructuredDebugStatement = true;
+        if (node.init.callee.name === 'render') {
+          if (
+            node.id.type === 'ObjectPattern' &&
+            node.id.properties.some(property => property.key.name === 'debug')
+          ) {
+            hasDestructuredDebugStatement = true;
+          }
+
+          if (node.id.type === 'Identifier') {
+            renderVariableDeclarators.push(node);
+          }
         }
       },
-      'Program:exit'() {},
-      [`CallExpression > Identifier[name = "debug"]`](node) {
+      [`CallExpression > Identifier[name="debug"]`](node) {
         if (hasDestructuredDebugStatement) {
           context.report({
             node,
             messageId: 'noDebug',
           });
         }
+      },
+      'Program:exit'() {
+        renderVariableDeclarators.forEach(renderVar => {
+          const renderVarReferences = context
+            .getDeclaredVariables(renderVar)[0]
+            .references.slice(1);
+          renderVarReferences.forEach(ref => {
+            const parent = ref.identifier.parent;
+            if (
+              parent &&
+              parent.type === 'MemberExpression' &&
+              parent.property.name === 'debug' &&
+              parent.parent.type === 'CallExpression'
+            ) {
+              context.report({
+                node: parent.property,
+                messageId: 'noDebug',
+              });
+            }
+          });
+        });
       },
     };
   },

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -17,9 +17,20 @@ module.exports = {
   },
 
   create: function(context) {
+    let hasDestructuredDebugStatement = false;
     return {
-      Identifier(node) {
-        if (node.name === 'debug') {
+      VariableDeclarator(node) {
+        if (
+          node.init.callee.name === 'render' &&
+          node.id.type === 'ObjectPattern' &&
+          node.id.properties.some(property => property.key.name === 'debug')
+        ) {
+          hasDestructuredDebugStatement = true;
+        }
+      },
+      'Program:exit'() {},
+      [`CallExpression > Identifier[name = "debug"]`](node) {
+        if (hasDestructuredDebugStatement) {
           context.report({
             node,
             messageId: 'noDebug',

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unnecessary debug usages in the tests',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'TODO',
+    },
+    messages: {
+      noDebug: 'Unexpected debug statement',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  create: function(context) {
+    return {
+      Identifier(node) {
+        if (node.name === 'debug') {
+          context.report({
+            node,
+            messageId: 'noDebug',
+          });
+        }
+      },
+    };
+  },
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const getDocsUrl = ruleName =>
+  `https://github.com/Belco90/eslint-plugin-testing-library/tree/master/docs/rules/${ruleName}.md`;
+
+module.exports = {
+  getDocsUrl,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,60 @@
 'use strict';
 
+const combineQueries = (variants, methods) => {
+  const combinedQueries = [];
+  variants.forEach(variant => {
+    const variantPrefix = variant.replace('By', '');
+    methods.forEach(method => {
+      combinedQueries.push(`${variantPrefix}${method}`);
+    });
+  });
+
+  return combinedQueries;
+};
+
 const getDocsUrl = ruleName =>
   `https://github.com/Belco90/eslint-plugin-testing-library/tree/master/docs/rules/${ruleName}.md`;
 
+const SYNC_QUERIES_VARIANTS = ['getBy', 'getAllBy', 'queryBy', 'queryAllBy'];
+const ASYNC_QUERIES_VARIANTS = ['findBy', 'findAllBy'];
+const ALL_QUERIES_VARIANTS = [
+  ...SYNC_QUERIES_VARIANTS,
+  ...ASYNC_QUERIES_VARIANTS,
+];
+
+const ALL_QUERIES_METHODS = [
+  'ByLabelText',
+  'ByPlaceholderText',
+  'ByText',
+  'ByAltText',
+  'ByTitle',
+  'ByDisplayValue',
+  'ByRole',
+  'ByTestId',
+];
+
+const SYNC_QUERIES_COMBINATIONS = combineQueries(
+  SYNC_QUERIES_VARIANTS,
+  ALL_QUERIES_METHODS
+);
+
+const ASYNC_QUERIES_COMBINATIONS = combineQueries(
+  ASYNC_QUERIES_VARIANTS,
+  ALL_QUERIES_METHODS
+);
+
+const ALL_QUERIES_COMBINATIONS = [
+  SYNC_QUERIES_COMBINATIONS,
+  ASYNC_QUERIES_COMBINATIONS,
+];
+
 module.exports = {
   getDocsUrl,
+  SYNC_QUERIES_VARIANTS,
+  ASYNC_QUERIES_VARIANTS,
+  ALL_QUERIES_VARIANTS,
+  ALL_QUERIES_METHODS,
+  SYNC_QUERIES_COMBINATIONS,
+  ASYNC_QUERIES_COMBINATIONS,
+  ALL_QUERIES_COMBINATIONS,
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "lint": "eslint ./",
     "lint:fix": "npm run lint -- --fix",
+    "format": "prettier --write README.md {lib,docs,tests}/**/*.{js,md}",
     "test": "jest"
   },
   "dependencies": {},

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -11,17 +11,45 @@ const RuleTester = require('eslint').RuleTester;
 // Tests
 // ------------------------------------------------------------------------------
 
-const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
 ruleTester.run('no-debug', rule, {
   valid: [
     {
-      code: `foo`,
+      code: `debug()`,
+    },
+    {
+      code: `() => {
+        const { debug } = foo()
+        debug()
+      }`,
+    },
+    {
+      code: `
+        const debug = require('debug')
+        debug()
+      `,
+    },
+    {
+      code: `
+        const { test } = render(<Component/>)
+        test()
+      `,
     },
   ],
 
   invalid: [
     {
-      code: `debug()`,
+      code: `
+        const { debug } = render(<Component/>)
+        debug()
+      `,
       errors: [
         {
           messageId: 'noDebug',

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -42,6 +42,18 @@ ruleTester.run('no-debug', rule, {
         test()
       `,
     },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.debug
+      `,
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.foo()
+      `,
+    },
   ],
 
   invalid: [
@@ -51,6 +63,33 @@ ruleTester.run('no-debug', rule, {
         debug()
       `,
       errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.debug()
+      `,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.debug()
+        utils.foo()
+        utils.debug()
+      `,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
         {
           messageId: 'noDebug',
         },

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-debug');
+const RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({ parserOptions: { ecmaVersion: 2018 } });
+ruleTester.run('no-debug', rule, {
+  valid: [
+    {
+      code: `foo`,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `debug()`,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This PR intends to add a new rule called `no-debug`.

Indeed, just like `console.log` statements pollutes the browser's output, debug statements can also pollute the tests:

```js
import React from 'react'
import { render } from '@testing-library/react'

const HelloWorld = () => <h1>Hello World</h1>
const { debug } = render(<HelloWorld />)
debug()
// <div>
//   <h1>Hello World</h1>
// </div>
```

This rule would prevent developers to push unwanted debug statements to the codebase by warning them that it has been used.