### PR TITLE
feat: add no-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ To enable this configuration use the `extends` property in your `.eslintrc` conf
 | -------------------------------------------------------- | --------------------------------------------- | ---------------- |
 | [await-async-query](docs/rules/await-async-query.md)     | Enforce async queries to have proper `await`  | ![recommended][] |
 | [no-await-sync-query](docs/rules/no-await-sync-query.md) | Disallow unnecessary `await` for sync queries | ![recommended][] |
+| [no-debug](docs/rules/no-debug.md)                       | Disallow the use of `debug`                   |                  |
 
 [recommended]: https://img.shields.io/badge/recommended-lightgrey?style=flat-square

--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -1,0 +1,21 @@
+# Disallow the use of `debug` (no-debug)
+
+Just like `console.log` statements pollutes the browser's output, debug statements also pollutes the tests if one of your team mates forgot to remove it. `debug` statements should be used when you actually want to debug your tests but should not be pushed to the codebase.
+
+## Rule Details
+
+This rule aims to disallow the use of `debug` in your tests.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const { debug } = render(<Hello />);
+debug();
+// OR
+const utils = render(<Hello />);
+utils.debug();
+```
+
+## Further Reading
+
+- [debug API in React Testing Library](https://testing-library.com/docs/react-testing-library/api#debug)

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -1,0 +1,68 @@
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unnecessary debug usages in the tests',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'TODO',
+    },
+    messages: {
+      noDebug: 'Unexpected debug statement',
+    },
+    fixable: null,
+    schema: [],
+  },
+
+  create: function(context) {
+    let hasDestructuredDebugStatement = false;
+    const renderVariableDeclarators = [];
+    return {
+      VariableDeclarator(node) {
+        if (node.init.callee.name === 'render') {
+          if (
+            node.id.type === 'ObjectPattern' &&
+            node.id.properties.some(property => property.key.name === 'debug')
+          ) {
+            hasDestructuredDebugStatement = true;
+          }
+
+          if (node.id.type === 'Identifier') {
+            renderVariableDeclarators.push(node);
+          }
+        }
+      },
+      [`CallExpression > Identifier[name="debug"]`](node) {
+        if (hasDestructuredDebugStatement) {
+          context.report({
+            node,
+            messageId: 'noDebug',
+          });
+        }
+      },
+      'Program:exit'() {
+        renderVariableDeclarators.forEach(renderVar => {
+          const renderVarReferences = context
+            .getDeclaredVariables(renderVar)[0]
+            .references.slice(1);
+          renderVarReferences.forEach(ref => {
+            const parent = ref.identifier.parent;
+            if (
+              parent &&
+              parent.type === 'MemberExpression' &&
+              parent.property.name === 'debug' &&
+              parent.parent.type === 'CallExpression'
+            ) {
+              context.report({
+                node: parent.property,
+                messageId: 'noDebug',
+              });
+            }
+          });
+        });
+      },
+    };
+  },
+};

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { getDocsUrl } = require('../utils');
+
 module.exports = {
   meta: {
     type: 'problem',
@@ -7,7 +9,7 @@ module.exports = {
       description: 'Disallow unnecessary debug usages in the tests',
       category: 'Best Practices',
       recommended: true,
-      url: 'TODO',
+      url: getDocsUrl('no-debug'),
     },
     messages: {
       noDebug: 'Unexpected debug statement',

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -1,0 +1,99 @@
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-debug');
+const RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+});
+ruleTester.run('no-debug', rule, {
+  valid: [
+    {
+      code: `debug()`,
+    },
+    {
+      code: `() => {
+        const { debug } = foo()
+        debug()
+      }`,
+    },
+    {
+      code: `
+        const debug = require('debug')
+        debug()
+      `,
+    },
+    {
+      code: `
+        const { test } = render(<Component/>)
+        test()
+      `,
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.debug
+      `,
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.foo()
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `
+        const { debug } = render(<Component/>)
+        debug()
+      `,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.debug()
+      `,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
+        const utils = render(<Component/>)
+        utils.debug()
+        utils.foo()
+        utils.debug()
+      `,
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This PR intends to add a new rule called `no-debug`.

Indeed, just like `console.log` statements pollutes the browser's output, debug statements can also pollute the tests:

```js
import React from 'react'
import { render } from '@testing-library/react'

const HelloWorld = () => <h1>Hello World</h1>
const { debug } = render(<HelloWorld />)
debug()
// <div>
//   <h1>Hello World</h1>
// </div>
```

This rule would prevent developers to push unwanted debug statements to the codebase by warning them that it has been used.