### PR TITLE
fix: immediately awaited assign to var

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,6 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged",
+    "pre-commit": "npm run test && lint-staged",
     "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
   }
 }

--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -30,7 +30,9 @@ module.exports = {
     const testingLibraryQueryUsage = [];
     return {
       [`CallExpression > Identifier[name=${ASYNC_QUERIES_REGEXP}]`](node) {
-        testingLibraryQueryUsage.push(node);
+        if (!isAwaited(node.parent.parent) && !isPromiseResolved(node)) {
+          testingLibraryQueryUsage.push(node);
+        }
       },
       'Program:exit'() {
         testingLibraryQueryUsage.forEach(node => {

--- a/tests/lib/rules/await-async-query.js
+++ b/tests/lib/rules/await-async-query.js
@@ -44,6 +44,16 @@ ruleTester.run('await-async-query', rule, {
       `,
     })),
 
+    // async queries saving element in var with promise immediately resolved are valid
+    ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
+      code: `async () => {
+        doSomething()
+        const foo = ${query}('foo').then(node => node)
+        expect(foo).toBeInTheDocument();
+      }
+      `,
+    })),
+
     // async queries with promise in variable and await operator are valid
     ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
       code: `async () => {


### PR DESCRIPTION
We had a failing test case where an immediately awaited call assigned to a var would be tracked by our rule. This PR intends to fix this behavior for `await` and `.then`.

I also made sure the tests would be run on each commit to add a layer of safety in case someone commits code that would make tests fail. Tell me if you're OK with this 🙂