### PR TITLE
feat: suggest proper framework to import from

### DIFF
--- a/docs/rules/no-dom-import.md
+++ b/docs/rules/no-dom-import.md
@@ -57,6 +57,20 @@ const { fireEvent } = require('react-testing-library');
 const { fireEvent } = require('@testing-library/react');
 ```
 
+## Options
+
+This rule has an option in case you want to tell the user which framework to use.
+
+### Example
+
+```json
+{
+  "testing-library/no-dom-import": ["error", "react"]
+}
+```
+
+With the configuration above, if the user imports from `@testing-library/dom` or `dom-testing-library` instead of the used framework, ESLint will tell the user to import from `@testing-library/react` or `react-testing-library`.
+
 ## Further Reading
 
 - [Angular Testing Library API](https://testing-library.com/docs/angular-testing-library/api)

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,15 +20,27 @@ module.exports = {
     },
     angular: {
       plugins: ['testing-library'],
-      rules: { ...recommendedRules, 'testing-library/no-debug': 'warn' },
+      rules: {
+        ...recommendedRules,
+        'testing-library/no-debug': 'warn',
+        'testing/library/no-dom-import': ['error', 'angular'],
+      },
     },
     react: {
       plugins: ['testing-library'],
-      rules: { ...recommendedRules, 'testing-library/no-debug': 'warn' },
+      rules: {
+        ...recommendedRules,
+        'testing-library/no-debug': 'warn',
+        'testing/library/no-dom-import': ['error', 'react'],
+      },
     },
     vue: {
       plugins: ['testing-library'],
-      rules: { ...recommendedRules, 'testing-library/no-debug': 'warn' },
+      rules: {
+        ...recommendedRules,
+        'testing-library/no-debug': 'warn',
+        'testing/library/no-dom-import': ['error', 'vue'],
+      },
     },
   },
 };

--- a/lib/rules/no-dom-import.js
+++ b/lib/rules/no-dom-import.js
@@ -20,7 +20,7 @@ module.exports = {
       noDomImport:
         'import from DOM Testing Library is restricted, import from corresponding Testing Library framework instead',
       noDomImportFramework:
-        'import from DOM Testing Library is restricted, import from @testing-library/{{name}} instead',
+        'import from DOM Testing Library is restricted, import from {{module}} instead',
     },
     fixable: null,
     schema: [
@@ -35,29 +35,35 @@ module.exports = {
 
     return {
       ImportDeclaration(node) {
-        if (DOM_TESTING_LIBRARY_MODULES.includes(node.source.value)) {
-          report(context, node, framework);
+        const domModuleName = DOM_TESTING_LIBRARY_MODULES.find(
+          module => module === node.source.value
+        );
+
+        if (domModuleName) {
+          report(context, node, domModuleName);
         }
       },
 
       [`CallExpression > Identifier[name="require"]`](node) {
         const { arguments: args } = node.parent;
 
-        if (
-          args.some(args => DOM_TESTING_LIBRARY_MODULES.includes(args.value))
-        ) {
-          report(context, node, framework);
+        const literalNodeDomModuleName = args.find(args =>
+          DOM_TESTING_LIBRARY_MODULES.includes(args.value)
+        );
+
+        if (literalNodeDomModuleName) {
+          report(context, node, literalNodeDomModuleName.value);
         }
       },
     };
 
-    function report(context, node, framework) {
+    function report(context, node, moduleName) {
       if (framework) {
         context.report({
           node,
           messageId: 'noDomImportFramework',
           data: {
-            name: framework,
+            module: moduleName.replace('dom', framework),
           },
         });
       } else {

--- a/lib/rules/no-dom-import.js
+++ b/lib/rules/no-dom-import.js
@@ -18,20 +18,25 @@ module.exports = {
     },
     messages: {
       noDomImport:
-        'import from DOM Testing Library is restricted, import from corresponding Testing library framework instead',
+        'import from DOM Testing Library is restricted, import from corresponding Testing Library framework instead',
+      noDomImportFramework:
+        'import from DOM Testing Library is restricted, import from @testing-library/{{name}} instead',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'string',
+      },
+    ],
   },
 
   create: function(context) {
+    const framework = context.options[0];
+
     return {
       ImportDeclaration(node) {
         if (DOM_TESTING_LIBRARY_MODULES.includes(node.source.value)) {
-          context.report({
-            node,
-            messageId: 'noDomImport',
-          });
+          report(context, node, framework);
         }
       },
 
@@ -41,12 +46,26 @@ module.exports = {
         if (
           args.some(args => DOM_TESTING_LIBRARY_MODULES.includes(args.value))
         ) {
-          context.report({
-            node,
-            messageId: 'noDomImport',
-          });
+          report(context, node, framework);
         }
       },
     };
+
+    function report(context, node, framework) {
+      if (framework) {
+        context.report({
+          node,
+          messageId: 'noDomImportFramework',
+          data: {
+            name: framework,
+          },
+        });
+      } else {
+        context.report({
+          node,
+          messageId: 'noDomImport',
+        });
+      }
+    }
   },
 };

--- a/lib/rules/no-dom-import.js
+++ b/lib/rules/no-dom-import.js
@@ -22,7 +22,7 @@ module.exports = {
       noDomImportFramework:
         'import from DOM Testing Library is restricted, import from {{module}} instead',
     },
-    fixable: null,
+    fixable: 'code',
     schema: [
       {
         type: 'string',
@@ -59,11 +59,29 @@ module.exports = {
 
     function report(context, node, moduleName) {
       if (framework) {
+        const isRequire = node.name === 'require';
+        const correctModuleName = moduleName.replace('dom', framework);
         context.report({
           node,
           messageId: 'noDomImportFramework',
           data: {
-            module: moduleName.replace('dom', framework),
+            module: correctModuleName,
+          },
+          fix(fixer) {
+            if (isRequire) {
+              const name = node.parent.arguments[0];
+              // Replace the module name with the raw module name as we can't predict which punctuation the user is going to use
+              return fixer.replaceText(
+                name,
+                name.raw.replace(moduleName, correctModuleName)
+              );
+            } else {
+              const name = node.source;
+              return fixer.replaceText(
+                name,
+                name.raw.replace(moduleName, correctModuleName)
+              );
+            }
           },
         });
       } else {

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -9,6 +9,10 @@ Object {
     "testing-library/await-async-query": "error",
     "testing-library/no-await-sync-query": "error",
     "testing-library/no-debug": "warn",
+    "testing/library/no-dom-import": Array [
+      "error",
+      "angular",
+    ],
   },
 }
 `;
@@ -22,6 +26,10 @@ Object {
     "testing-library/await-async-query": "error",
     "testing-library/no-await-sync-query": "error",
     "testing-library/no-debug": "warn",
+    "testing/library/no-dom-import": Array [
+      "error",
+      "react",
+    ],
   },
 }
 `;
@@ -47,6 +55,10 @@ Object {
     "testing-library/await-async-query": "error",
     "testing-library/no-await-sync-query": "error",
     "testing-library/no-debug": "warn",
+    "testing/library/no-dom-import": Array [
+      "error",
+      "vue",
+    ],
   },
 }
 `;

--- a/tests/lib/rules/no-dom-import.js
+++ b/tests/lib/rules/no-dom-import.js
@@ -36,6 +36,16 @@ ruleTester.run('no-dom-import', rule, {
       ],
     },
     {
+      code: 'import { fireEvent } from "dom-testing-library"',
+      options: ['react'],
+      errors: [
+        {
+          message:
+            'import from DOM Testing Library is restricted, import from @testing-library/react instead',
+        },
+      ],
+    },
+    {
       code: 'import * as testing from "dom-testing-library"',
       errors: [
         {
@@ -88,6 +98,16 @@ ruleTester.run('no-dom-import', rule, {
       errors: [
         {
           messageId: 'noDomImport',
+        },
+      ],
+    },
+    {
+      code: 'const { fireEvent } = require("@testing-library/dom")',
+      options: ['vue'],
+      errors: [
+        {
+          message:
+            'import from DOM Testing Library is restricted, import from @testing-library/vue instead',
         },
       ],
     },

--- a/tests/lib/rules/no-dom-import.js
+++ b/tests/lib/rules/no-dom-import.js
@@ -34,6 +34,7 @@ ruleTester.run('no-dom-import', rule, {
           messageId: 'noDomImport',
         },
       ],
+      output: 'import { fireEvent } from "dom-testing-library"',
     },
     {
       code: 'import { fireEvent } from "dom-testing-library"',
@@ -44,6 +45,19 @@ ruleTester.run('no-dom-import', rule, {
             'import from DOM Testing Library is restricted, import from react-testing-library instead',
         },
       ],
+      output: `import { fireEvent } from "react-testing-library"`,
+    },
+    // Single quote or double quotes should not be replaced
+    {
+      code: `import { fireEvent } from 'dom-testing-library'`,
+      options: ['react'],
+      errors: [
+        {
+          message:
+            'import from DOM Testing Library is restricted, import from react-testing-library instead',
+        },
+      ],
+      output: `import { fireEvent } from 'react-testing-library'`,
     },
     {
       code: 'import * as testing from "dom-testing-library"',
@@ -110,6 +124,7 @@ ruleTester.run('no-dom-import', rule, {
             'import from DOM Testing Library is restricted, import from @testing-library/vue instead',
         },
       ],
+      output: 'const { fireEvent } = require("@testing-library/vue")',
     },
     {
       code: 'require("dom-testing-library")',

--- a/tests/lib/rules/no-dom-import.js
+++ b/tests/lib/rules/no-dom-import.js
@@ -41,7 +41,7 @@ ruleTester.run('no-dom-import', rule, {
       errors: [
         {
           message:
-            'import from DOM Testing Library is restricted, import from @testing-library/react instead',
+            'import from DOM Testing Library is restricted, import from react-testing-library instead',
         },
       ],
     },


### PR DESCRIPTION
Just one thing to check before merging. The corresponding error message for a framework is the following: 

```
import from DOM Testing Library is restricted, import from @testing-library/{{name}} instead
```

Should we keep the same error message if the user is using the old libraries (`react-testing-library` for example)? I assume yes as the old ones are deprecated, but still I wanted to check that with you.