### PR TITLE
fix(await-async-query): avoid duplicated reports

### DIFF
--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -61,7 +61,7 @@ module.exports = {
               },
             });
           } else {
-            references.forEach(reference => {
+            for (const reference of references) {
               const referenceNode = reference.identifier;
               if (
                 !isAwaited(referenceNode.parent) &&
@@ -74,8 +74,10 @@ module.exports = {
                     name: node.name,
                   },
                 });
+
+                break;
               }
-            });
+            }
           }
         });
       },

--- a/tests/lib/rules/await-async-query.js
+++ b/tests/lib/rules/await-async-query.js
@@ -139,10 +139,12 @@ ruleTester.run('await-async-query', rule, {
         code: `async () => {
         const foo = ${query}('foo')
         expect(foo).toBeInTheDocument()
+        expect(foo).toHaveAttribute('src', 'bar');
       }
       `,
         errors: [
           {
+            line: 2,
             message: `\`${query}\` must have \`await\` operator`,
           },
         ],


### PR DESCRIPTION
Avoid duplicated errors for `await-async-query` for each use of the var declarated.