### PR TITLE
feat(no-debug): render function names

### DIFF
--- a/docs/rules/no-debug.md
+++ b/docs/rules/no-debug.md
@@ -16,6 +16,12 @@ const utils = render(<Hello />);
 utils.debug();
 ```
 
+If you use [custom render functions](https://testing-library.com/docs/example-react-redux) then you can set a config option in your `.eslintrc` to look for these.
+
+```
+   "testing-library/no-debug": ["error", {"renderFunctions":["renderWithRedux", "renderWithRouter"]}],
+```
+
 ## Further Reading
 
 - [debug API in React Testing Library](https://testing-library.com/docs/react-testing-library/api#debug)

--- a/lib/rules/no-debug.js
+++ b/lib/rules/no-debug.js
@@ -15,18 +15,35 @@ module.exports = {
       noDebug: 'Unexpected debug statement',
     },
     fixable: null,
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          renderFunctions: {
+            type: 'array',
+          },
+        },
+      },
+    ],
   },
 
   create: function(context) {
     let hasDestructuredDebugStatement = false;
     const renderVariableDeclarators = [];
+
+    let renderFunctions = [];
+    if (context.options && context.options.length > 0) {
+      [{ renderFunctions }] = context.options;
+    }
+
     return {
       VariableDeclarator(node) {
         if (
           node.init &&
           node.init.callee &&
-          node.init.callee.name === 'render'
+          ['render', ...renderFunctions].some(
+            name => name === node.init.callee.name
+          )
         ) {
           if (
             node.id.type === 'ObjectPattern' &&

--- a/tests/lib/rules/no-debug.js
+++ b/tests/lib/rules/no-debug.js
@@ -72,6 +72,22 @@ ruleTester.run('no-debug', rule, {
     },
     {
       code: `
+        const { debug } = renderWithRedux(<Component/>)
+        debug()
+      `,
+      options: [
+        {
+          renderFunctions: ['renderWithRedux'],
+        },
+      ],
+      errors: [
+        {
+          messageId: 'noDebug',
+        },
+      ],
+    },
+    {
+      code: `
         const utils = render(<Component/>)
         utils.debug()
       `,


### PR DESCRIPTION
we commonly wrap `render` with redux and other things, so having the ability to configure the render function names will be useful for us.