### PR TITLE
ci: limit branches to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ node_js:
   - 8
   - 10
 
+branches:
+  only: master
+
 jobs:
   include:
     - stage: release


### PR DESCRIPTION
Limit CI branches to master to avoid unnecessary builds in Travis. In previous PRs, builds were executed twice: one from PR and one from new push. This PR aims to fix that so we only have one build in that case.

Previous checks:
<img width="654" alt="image" src="https://user-images.githubusercontent.com/2677072/67765914-902ffa80-fa4d-11e9-93f9-569abf9efa21.png">

Current checks:
<img width="669" alt="image" src="https://user-images.githubusercontent.com/2677072/67765933-9e7e1680-fa4d-11e9-83e0-ace76a40b99c.png">
