### PR TITLE
Fix prefer-explicit-assert raising error on destructuring statement

### DIFF
--- a/lib/rules/prefer-explicit-assert.js
+++ b/lib/rules/prefer-explicit-assert.js
@@ -24,6 +24,11 @@ const isDeclared = node => node.parent.type === 'VariableDeclarator';
 const isReturnedByReturnStatement = node =>
   node.parent.type === 'ReturnStatement';
 
+const isInDestructuringStatement = node =>
+  (node.parent.type === 'Property' &&
+    node.parent.parent.type === 'ObjectPattern') ||
+  node.parent.type === 'ArrayPattern';
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -63,6 +68,7 @@ module.exports = {
 
         if (
           isValidQuery(node, customQueryNames) &&
+          !isInDestructuringStatement(node) &&
           !isDirectlyCalledByFunction(callExpressionNode) &&
           !isReturnedByArrowFunctionExpression(callExpressionNode) &&
           !isDeclared(callExpressionNode) &&

--- a/lib/rules/prefer-explicit-assert.js
+++ b/lib/rules/prefer-explicit-assert.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const { getDocsUrl, ALL_QUERIES_METHODS } = require('../utils');
+const { findParent, getDocsUrl, ALL_QUERIES_METHODS } = require('../utils');
 
 const ALL_GET_BY_QUERIES = ALL_QUERIES_METHODS.map(
   queryMethod => `get${queryMethod}`
 );
 
 const findCallExpressionParent = node =>
-  node.type === 'CallExpression' ? node : findCallExpressionParent(node.parent);
+  findParent(node, node => node.type === 'CallExpression');
 
 const isValidQuery = (node, customQueryNames = []) =>
   ALL_GET_BY_QUERIES.includes(node.name) ||
@@ -19,13 +19,11 @@ const isDirectlyCalledByFunction = node =>
 const isReturnedByArrowFunctionExpression = node =>
   node.parent.type === 'ArrowFunctionExpression';
 
-const isDeclared = node => node.parent.type === 'VariableDeclarator';
+const isDeclared = node =>
+  !!findParent(node, node => node.type === 'VariableDeclarator');
 
 const isReturnedByReturnStatement = node =>
   node.parent.type === 'ReturnStatement';
-
-const isInsideArrayDeclaration = node =>
-  node.parent.parent.type === 'ArrayExpression';
 
 const isInDestructuringStatement = node =>
   (node.parent.type === 'Property' &&
@@ -72,7 +70,6 @@ module.exports = {
         if (
           isValidQuery(node, customQueryNames) &&
           !isInDestructuringStatement(node) &&
-          !isInsideArrayDeclaration(node) &&
           !isDirectlyCalledByFunction(callExpressionNode) &&
           !isReturnedByArrowFunctionExpression(callExpressionNode) &&
           !isDeclared(callExpressionNode) &&

--- a/lib/rules/prefer-explicit-assert.js
+++ b/lib/rules/prefer-explicit-assert.js
@@ -24,6 +24,9 @@ const isDeclared = node => node.parent.type === 'VariableDeclarator';
 const isReturnedByReturnStatement = node =>
   node.parent.type === 'ReturnStatement';
 
+const isInsideArrayDeclaration = node =>
+  node.parent.parent.type === 'ArrayExpression';
+
 const isInDestructuringStatement = node =>
   (node.parent.type === 'Property' &&
     node.parent.parent.type === 'ObjectPattern') ||
@@ -69,6 +72,7 @@ module.exports = {
         if (
           isValidQuery(node, customQueryNames) &&
           !isInDestructuringStatement(node) &&
+          !isInsideArrayDeclaration(node) &&
           !isDirectlyCalledByFunction(callExpressionNode) &&
           !isReturnedByArrowFunctionExpression(callExpressionNode) &&
           !isDeclared(callExpressionNode) &&

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,7 +48,18 @@ const ALL_QUERIES_COMBINATIONS = [
   ASYNC_QUERIES_COMBINATIONS,
 ];
 
+const findParent = (node, cb) => {
+  if (cb(node)) {
+    return node;
+  } else if (node.parent) {
+    return findParent(node.parent, cb);
+  }
+
+  return null;
+};
+
 module.exports = {
+  findParent,
   getDocsUrl,
   SYNC_QUERIES_VARIANTS,
   ASYNC_QUERIES_VARIANTS,

--- a/tests/lib/rules/prefer-explicit-assert.js
+++ b/tests/lib/rules/prefer-explicit-assert.js
@@ -62,6 +62,9 @@ ruleTester.run('prefer-explicit-assert', rule, {
     {
       code: `const a = [ getByText('foo') ]`,
     },
+    {
+      code: `const a = { foo: getByText('bar') }`,
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-explicit-assert.js
+++ b/tests/lib/rules/prefer-explicit-assert.js
@@ -50,6 +50,15 @@ ruleTester.run('prefer-explicit-assert', rule, {
     {
       code: `getByIcon('foo')`, // custom `getBy` query not extended through options
     },
+    {
+      code: `const { getByText } = render()`,
+    },
+    {
+      code: `it('test', () => { const { getByText } = render() })`,
+    },
+    {
+      code: `it('test', () => { const [ getByText ] = render() })`,
+    },
   ],
 
   invalid: [

--- a/tests/lib/rules/prefer-explicit-assert.js
+++ b/tests/lib/rules/prefer-explicit-assert.js
@@ -59,6 +59,9 @@ ruleTester.run('prefer-explicit-assert', rule, {
     {
       code: `it('test', () => { const [ getByText ] = render() })`,
     },
+    {
+      code: `const a = [ getByText('foo') ]`,
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Closes #40.

I've added a check for Array destructuring. I've never seen it before, but I thought it wouldn't hurt.

Thanks for your help!