### PR TITLE
docs: fix broken link to prefer-expect-query-by

### DIFF
--- a/docs/rules/prefer-explicit-assert.md
+++ b/docs/rules/prefer-explicit-assert.md
@@ -76,7 +76,7 @@ method itself, then this rule is not recommended.
 
 ## Related Rules
 
-- [prefer-expect-query-by](docs/rules/prefer-expect-query-by.md)
+- [prefer-expect-query-by](prefer-expect-query-by.md)
 
 ## Further Reading
 


### PR DESCRIPTION
Fix a broken link in the docs from `prefer-explicit-assert.md` to `prefer-expect-query-by.md`.

URL Before (note "docs/rules/docs/rules"):
https://github.com/Belco90/eslint-plugin-testing-library/blob/master/docs/rules/docs/rules/prefer-expect-query-by.md

URL After:
https://github.com/Belco90/eslint-plugin-testing-library/blob/master/docs/rules/prefer-expect-query-by.md