### PR TITLE
fix: references is not iterable / cant parse expect(findBy*)

### DIFF
--- a/lib/rules/await-async-query.js
+++ b/lib/rules/await-async-query.js
@@ -39,10 +39,11 @@ module.exports = {
           const variableDeclaratorParent = node.parent.parent;
 
           const references =
-            variableDeclaratorParent.type === 'VariableDeclarator' &&
-            context
-              .getDeclaredVariables(variableDeclaratorParent)[0]
-              .references.slice(1);
+            (variableDeclaratorParent.type === 'VariableDeclarator' &&
+              context
+                .getDeclaredVariables(variableDeclaratorParent)[0]
+                .references.slice(1)) ||
+            [];
 
           if (
             references &&

--- a/tests/lib/rules/await-async-query.js
+++ b/tests/lib/rules/await-async-query.js
@@ -149,5 +149,17 @@ ruleTester.run('await-async-query', rule, {
           },
         ],
       })),
+      ...ASYNC_QUERIES_COMBINATIONS.map(query => ({
+        code: `async () => {
+        expect(${query}('foo')).toBeInTheDocument()
+      }
+      `,
+        errors: [
+          {
+            line: 2,
+            message: `\`${query}\` must have \`await\` operator`,
+          },
+        ],
+      })),
     ],
 });


### PR DESCRIPTION
The bug was caused by the fact that when a query is wrapped into a function, it is not referenced in the `getDeclaredVariables` call making the references equal to `false`.
It caused the references check to be false, to enter the else statement and thus trying to iterate over a false value.

Closes #48.