### PR TITLE
fix: prefer explicit assert should check if node property is accessed

### DIFF
--- a/lib/rules/prefer-explicit-assert.js
+++ b/lib/rules/prefer-explicit-assert.js
@@ -1,34 +1,16 @@
 'use strict';
 
-const { findParent, getDocsUrl, ALL_QUERIES_METHODS } = require('../utils');
+const { getDocsUrl, ALL_QUERIES_METHODS } = require('../utils');
 
 const ALL_GET_BY_QUERIES = ALL_QUERIES_METHODS.map(
   queryMethod => `get${queryMethod}`
 );
 
-const findCallExpressionParent = node =>
-  findParent(node, node => node.type === 'CallExpression');
-
 const isValidQuery = (node, customQueryNames = []) =>
   ALL_GET_BY_QUERIES.includes(node.name) ||
   customQueryNames.includes(node.name);
 
-const isDirectlyCalledByFunction = node =>
-  node.parent.type === 'CallExpression';
-
-const isReturnedByArrowFunctionExpression = node =>
-  node.parent.type === 'ArrowFunctionExpression';
-
-const isDeclared = node =>
-  !!findParent(node, node => node.type === 'VariableDeclarator');
-
-const isReturnedByReturnStatement = node =>
-  node.parent.type === 'ReturnStatement';
-
-const isInDestructuringStatement = node =>
-  (node.parent.type === 'Property' &&
-    node.parent.parent.type === 'ObjectPattern') ||
-  node.parent.type === 'ArrayPattern';
+const isAtTopLevel = node => node.parent.parent.type === 'ExpressionStatement';
 
 module.exports = {
   meta: {
@@ -58,28 +40,32 @@ module.exports = {
   },
 
   create: function(context) {
+    const getQueryCalls = [];
+    const customQueryNames =
+      (context.options && context.options.length > 0
+        ? context.options[0].customQueryNames
+        : []) || [];
+
     return {
       'CallExpression Identifier'(node) {
-        const callExpressionNode = findCallExpressionParent(node);
-
-        let customQueryNames;
-        if (context.options && context.options.length > 0) {
-          [{ customQueryNames }] = context.options;
+        if (isValidQuery(node, customQueryNames)) {
+          getQueryCalls.push(node);
         }
+      },
+      'Program:exit'() {
+        getQueryCalls.forEach(queryCall => {
+          const node =
+            queryCall.parent.type === 'MemberExpression'
+              ? queryCall.parent
+              : queryCall;
 
-        if (
-          isValidQuery(node, customQueryNames) &&
-          !isInDestructuringStatement(node) &&
-          !isDirectlyCalledByFunction(callExpressionNode) &&
-          !isReturnedByArrowFunctionExpression(callExpressionNode) &&
-          !isDeclared(callExpressionNode) &&
-          !isReturnedByReturnStatement(callExpressionNode)
-        ) {
-          context.report({
-            node,
-            messageId: 'preferExplicitAssert',
-          });
-        }
+          if (isAtTopLevel(node)) {
+            context.report({
+              node: queryCall,
+              messageId: 'preferExplicitAssert',
+            });
+          }
+        });
       },
     };
   },

--- a/tests/lib/rules/prefer-explicit-assert.js
+++ b/tests/lib/rules/prefer-explicit-assert.js
@@ -33,6 +33,9 @@ ruleTester.run('prefer-explicit-assert', rule, {
       code: `expect(getByText('foo')).toBeInTheDocument();`,
     },
     {
+      code: `expect(getByText('foo').bar).toBeInTheDocument()`,
+    },
+    {
       code: `async () => { await waitForElement(() => getByText('foo')) }`,
     },
     {


### PR DESCRIPTION
In cases like `expect(getBy("foo").bar)`, `bar` was considered as an identifier thus triggering the visited function (`CallExpression Identifier`) and reporting an error.

Instead of adding another check, the implementation is simpler: checking whether the node is at the top level or not (`ExpressionStatement`).

Closes #45 